### PR TITLE
Update post response to include createdDate and change default post s…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ build/
 .vscode/
 .env
 pg-healthcheck.sh
+
+.env*

--- a/backend/src/main/java/com/urban/backend/controller/PostController.java
+++ b/backend/src/main/java/com/urban/backend/controller/PostController.java
@@ -26,7 +26,7 @@ public class PostController {
     public ResponseEntity<PageResponse<PostResponse>> searchPosts(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "5") int size,
-            @RequestParam(defaultValue = "id") String sortBy) {
+            @RequestParam(defaultValue = "createdDate") String sortBy) {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, sortBy));
 

--- a/backend/src/main/java/com/urban/backend/dto/response/PostResponse.java
+++ b/backend/src/main/java/com/urban/backend/dto/response/PostResponse.java
@@ -3,20 +3,23 @@ package com.urban.backend.dto.response;
 import com.urban.backend.enums.PostType;
 import com.urban.backend.model.Post;
 
+import java.time.Instant;
 import java.util.UUID;
 
 public record PostResponse(
         UUID id,
         String title,
         String content,
-        PostType postType
+        PostType postType,
+        Instant createdDate
 ) {
     public static PostResponse fromPost(Post post) {
         return new PostResponse(
                 post.getId(),
                 post.getTitle(),
                 post.getContent(),
-                post.getPostType()
+                post.getPostType(),
+                post.getCreatedDate()
         );
     }
 }


### PR DESCRIPTION
This pull request updates the sorting behavior for posts and enhances the `PostResponse` DTO to include the creation date. These changes improve the user experience by enabling sorting by creation date and providing more detailed information in API responses.

### Updates to sorting behavior:
* [`backend/src/main/java/com/urban/backend/controller/PostController.java`](diffhunk://#diff-deff5c46aa7d112de5ddd0f4e9eee5c2a5c25345cc58592091d8d1007f414c92L29-R29): Changed the default sorting parameter from `id` to `createdDate` in the `searchPosts` method to sort posts by their creation date in descending order.

### Enhancements to `PostResponse` DTO:
* [`backend/src/main/java/com/urban/backend/dto/response/PostResponse.java`](diffhunk://#diff-fb4dd7ecebefebcea7629dae9030af9b794c645f56d85461fdea9c279341f915R6-R22): Added a new field `createdDate` of type `Instant` to the `PostResponse` record and updated the `fromPost` method to populate this field from the `Post` model.…orting to createdDate; extend .gitignore for .env files